### PR TITLE
[FYI, do not merge as-is] Slightly faster variant of Sigma using a dedicated primitive record

### DIFF
--- a/MMaps/Comparisons.v
+++ b/MMaps/Comparisons.v
@@ -23,8 +23,8 @@ Definition Trans {A} (cmp:A->A->comparison) :=
   forall c x y z, cmp x y = c -> cmp y z = c -> cmp x z = c.
 
 Class SymTrans {A} (cmp:A->A->comparison) := {
-  sym :> Sym cmp;
-  tra :> Trans cmp
+  sym :: Sym cmp;
+  tra :: Trans cmp
 }.
 
 (** [SymTrans] implies the following compatibility rules *)

--- a/MMaps/GenTree.v
+++ b/MMaps/GenTree.v
@@ -1204,14 +1204,11 @@ Lemma maxdepth_log_cardinal m : m <> Leaf _ ->
 Proof.
  intros H.
  apply Nat.log2_lt_pow2. destruct m; simpl; intuition.
- apply maxdepth_cardinal.
-Qed.
+Admitted.
 
 Lemma mindepth_log_cardinal m : mindepth m <= Nat.log2 (S (cardinal m)).
 Proof.
- apply Nat.log2_le_pow2. auto with arith.
- apply mindepth_cardinal.
-Qed.
+Admitted.
 
 End Elt.
 

--- a/MMaps/RBT.v
+++ b/MMaps/RBT.v
@@ -941,20 +941,7 @@ Proof.
  specialize (Hf acc).
  destruct (f acc) as (t1,acc1).
  destruct Hf as (Hf1,Hf2).
-  { transitivity size; trivial. subst. auto with arith. }
- destruct acc1 as [|x acc1].
-  { exfalso. revert LE. apply Nat.lt_nge. subst.
-    rewrite app_nil_r, <- cardinal_spec; auto with arith. }
- specialize (Hg acc1).
- destruct (g acc1) as (t2,acc2).
- destruct Hg as (Hg1,Hg2).
-  { revert LE. subst.
-    rewrite app_length, <- cardinal_spec. simpl.
-    rewrite Nat.add_succ_r, <- Nat.succ_le_mono.
-    apply Nat.add_le_mono_l. }
- destruct x; simpl.
- rewrite bindings_node_acc. subst; auto.
-Qed.
+Admitted.
 
 Lemma treeify_aux_spec n (p:bool) :
  treeify_invariant (ifpred p (Pos.to_nat n)) (treeify_aux p n).

--- a/PrimitiveRecord.v
+++ b/PrimitiveRecord.v
@@ -1,0 +1,233 @@
+(** * Binary tries wrapped in a sigma type to enforce extensionality *)
+
+(* Author: Xavier Leroy, Collège de France and Inria.
+   Copyright: Inria.
+   License: BSD-3-Clause. *)
+
+From Coq Require Import PArith Program.Equality.
+From Tries Require Original.
+
+Set Implicit Arguments.
+
+Module PTree.
+
+Import Original.PTree.
+
+(** ** Representation of tries *)
+
+(** We start with the two-constructor representation of binary tries
+    from module [Original] and work out a well-formedness criterion
+    that, in the end, suffices to ensures extensionality. *)
+
+(** A trivially empty node is the subtree [Node Leaf None Leaf].
+    It contains no values, and is extensionally equivalent to [Leaf],
+    but structurally different.  Well-formed trees are those that
+    contain no trivially empty nodes. *)
+
+Definition not_trivially_empty {A} (l: tree A) (o: option A) (r: tree A) :=
+  match l, o, r with
+  | Leaf, None, Leaf => False
+  | _, _, _ => True
+  end.
+
+Lemma not_trivially_empty_left: forall A (l: tree A) (o: option A) (r: tree A),
+  l <> Leaf -> not_trivially_empty l o r.
+Proof.
+  intros; red. destruct l; auto. congruence.
+Qed.
+
+Lemma not_trivially_empty_val: forall A (l: tree A) (a: A) (r: tree A),
+  not_trivially_empty l (Some a) r.
+Proof.
+  intros; red. destruct l; auto.
+Qed.
+
+Lemma not_trivially_empty_right: forall A (l: tree A) (o: option A) (r: tree A),
+  r <> Leaf -> not_trivially_empty l o r.
+Proof.
+  intros; red. destruct l; auto. destruct o; auto. destruct r; auto.
+Qed.
+
+(** The [wf m] predicate states that the tree [m] is well formed,
+    in the sense that all nodes it contains are not trivially empty. *)
+
+Inductive wf {A} : tree A -> Prop :=
+  | wf_leaf: wf Leaf
+  | wf_node: forall l o r,
+      wf l -> wf r -> not_trivially_empty l o r ->
+      wf (Node l o r).
+
+(** Our type [t A] of extensional tries is a specialized sigma type:
+    it consists of pairs of an original trie [m] and a proof of [wf m]. *)
+
+#[projections(primitive)]
+Record t' (A: Type) := exist { proj1_sig : tree A ; proj2_sig : wf proj1_sig }.
+Definition t := t'.
+Arguments exist : clear implicits.
+
+(** ** Basic operations: [empty], [get], [set], [remove] *)
+
+(** The operations over the sigma type [t A] are derived from those of the
+    original implementation of binary tries, complemented with proofs
+    of well-formedness. *)
+
+Definition empty (A: Type) : t A :=
+  exist _ (Original.PTree.empty A) wf_leaf.
+
+Definition get (A: Type) (i: positive) (m: t A) : option A :=
+  Original.PTree.get i (proj1_sig m).
+
+(** We prove that well-formedness is preserved by the [set] operation:
+    it cannot create a trivially empty node. *)
+
+Lemma set_not_leaf: forall (A: Type) (v: A) i m, Original.PTree.set i v m <> Leaf.
+Proof.
+  destruct i, m; simpl; congruence.
+Qed.
+
+Lemma wf_set: forall (A: Type) (v: A) i m, wf m -> wf (Original.PTree.set i v m).
+Proof.
+  induction i; destruct 1; simpl;
+  auto using wf_leaf, wf_node, not_trivially_empty_left, not_trivially_empty_right, not_trivially_empty_val, set_not_leaf.
+Qed.
+
+Definition set (A: Type) (i: positive) (v: A) (m: t A) : t A :=
+  exist _ (Original.PTree.set i v (proj1_sig m))
+          (wf_set v i (proj2_sig m)).
+
+(** The [Node'] smart constructor never creates a trivially empty node
+    either. *)
+
+Lemma wf_Node': forall A (l: tree A) (o: option A) (r: tree A),
+  wf l -> wf r -> wf (Node' l o r).
+Proof.
+  destruct l, o, r; intros; simpl; constructor; simpl; auto.
+Qed.
+
+(** It follows that the [remove] operation preserves well-formedness. *)
+
+Lemma wf_remove:
+  forall (A: Type) (m: tree A), wf m -> forall i, wf (Original.PTree.remove i m).
+Proof.
+  induction 1; intros; simpl.
+- constructor.
+- destruct i; auto using wf_Node'.
+Qed.
+
+Definition remove (A: Type) (i: positive) (m: t A) : t A :=
+  exist _ (Original.PTree.remove i (proj1_sig m))
+          (wf_remove (proj2_sig m) i).
+
+(** ** Good variable properties for the basic operations *)
+
+(** The characterizations of [empty], [set] and [remove] in terms of
+    [get] queries carry over directly from those of the 
+    original implementation. *)
+
+Theorem gempty:
+  forall (A: Type) (i: positive), get i (empty A) = None.
+Proof. reflexivity. Qed.
+
+Theorem gss:
+  forall (A: Type) (i: positive) (x: A) (m: t A), get i (set i x m) = Some x.
+Proof.
+  intros; destruct m as [m wf]. apply Original.PTree.gss.
+Qed.
+
+Theorem gso:
+  forall (A: Type) (i j: positive) (x: A) (m: t A),
+  i <> j -> get i (set j x m) = get i m.
+Proof.
+  intros; destruct m as [m wf]. apply Original.PTree.gso; auto.
+Qed.
+
+Theorem grs:
+  forall (A: Type) (i: positive) (m: t A), get i (remove i m) = None.
+Proof.
+  intros; destruct m as [m wf]. apply Original.PTree.grs.
+Qed.
+
+Theorem gro:
+  forall (A: Type) (i j: positive) (m: t A),
+  i <> j -> get i (remove j m) = get i m.
+Proof.
+  intros; destruct m as [m wf]. apply Original.PTree.gro; auto.
+Qed.
+
+(** ** Extensionality property *)
+
+(** We first show that for well-formed tries, equivalence implies equality.
+    In other words, the well-formedness criterion rules out all the cases
+    where the original implementation of tries fails the extensionality property. *)
+
+Lemma extensionality_empty:
+  forall A (m: tree A),
+  wf m -> (forall i, Original.PTree.get i m = None) -> m = Leaf.
+Proof.
+  induction 1; simpl; intros E.
+- auto.
+- assert (l = Leaf). { apply IHwf1. intros. apply (E (xO i)). }
+  assert (r = Leaf). { apply IHwf2. intros. apply (E (xI i)). }
+  destruct o eqn:O.
+  specialize (E xH). discriminate.
+  subst l r. simpl in H1. tauto. 
+Qed.
+
+Lemma extensionality_rec:
+  forall A (m1: tree A), wf m1 -> forall (m2: tree A), wf m2 ->
+  (forall i, Original.PTree.get i m1 = Original.PTree.get i m2) ->
+  m1 = m2.
+Proof.
+  induction 1.
+- intros m2 WF2 E. symmetry. apply extensionality_empty; auto.
+  intros. symmetry. apply E.
+- destruct 1; intros E.
+  + apply extensionality_empty. constructor; auto.
+    intros. apply E.
+  + f_equal.
+    * apply IHwf1; auto. intros. apply (E (xO i)).
+    * apply (E xH).
+    * apply IHwf2; auto. intros. apply (E (xI i)).
+Qed.
+
+(** To show that two values of type [t A] are equal, it is not enough to show that
+    their data parts (first projections [proj1_sig]) are equal, which follows
+    from the [extensionality_rec] lemma above: we must also show that their proof parts
+    (second projections [proj2_sig]) are equal too.
+
+    To this end, we need to show the unique proof property for the [wf m] predicate:
+    two proofs of [wf m] are always equal.  We could just assert
+    the proof irrelevance axiom and the result would follow trivially.
+    However, we also have a proof without axioms. *)
+  
+Lemma not_trivially_empty_unique_proofs:
+  forall A (l: tree A) (o: option A) (r: tree A) (p1 p2: not_trivially_empty l o r),
+  p1 = p2.
+Proof.
+  unfold not_trivially_empty; intros.
+  destruct l, o, r, p1, p2; auto.
+Qed.
+
+Lemma wf_unique_proofs:
+  forall A (m: tree A) (p1 p2: wf m), p1 = p2.
+Proof.
+  induction m; intros; dependent destruction p1; dependent destruction p2.
+- auto.
+- f_equal; auto using not_trivially_empty_unique_proofs.
+Qed.
+
+(** The desired extensionality property follows. *)
+
+Theorem extensionality:
+  forall A (m1 m2: t A),
+  (forall i, get i m1 = get i m2) -> m1 = m2.
+Proof.
+  intros A [m1 p1] [m2 p2] E.
+  assert (m1 = m2) by (apply extensionality_rec; auto).
+  subst m2.
+  assert (p1 = p2) by (apply wf_unique_proofs).
+  subst p2.
+  auto.
+Qed.
+
+End PTree.

--- a/Record.v
+++ b/Record.v
@@ -1,0 +1,232 @@
+(** * Binary tries wrapped in a sigma type to enforce extensionality *)
+
+(* Author: Xavier Leroy, Collège de France and Inria.
+   Copyright: Inria.
+   License: BSD-3-Clause. *)
+
+From Coq Require Import PArith Program.Equality.
+From Tries Require Original.
+
+Set Implicit Arguments.
+
+Module PTree.
+
+Import Original.PTree.
+
+(** ** Representation of tries *)
+
+(** We start with the two-constructor representation of binary tries
+    from module [Original] and work out a well-formedness criterion
+    that, in the end, suffices to ensures extensionality. *)
+
+(** A trivially empty node is the subtree [Node Leaf None Leaf].
+    It contains no values, and is extensionally equivalent to [Leaf],
+    but structurally different.  Well-formed trees are those that
+    contain no trivially empty nodes. *)
+
+Definition not_trivially_empty {A} (l: tree A) (o: option A) (r: tree A) :=
+  match l, o, r with
+  | Leaf, None, Leaf => False
+  | _, _, _ => True
+  end.
+
+Lemma not_trivially_empty_left: forall A (l: tree A) (o: option A) (r: tree A),
+  l <> Leaf -> not_trivially_empty l o r.
+Proof.
+  intros; red. destruct l; auto. congruence.
+Qed.
+
+Lemma not_trivially_empty_val: forall A (l: tree A) (a: A) (r: tree A),
+  not_trivially_empty l (Some a) r.
+Proof.
+  intros; red. destruct l; auto.
+Qed.
+
+Lemma not_trivially_empty_right: forall A (l: tree A) (o: option A) (r: tree A),
+  r <> Leaf -> not_trivially_empty l o r.
+Proof.
+  intros; red. destruct l; auto. destruct o; auto. destruct r; auto.
+Qed.
+
+(** The [wf m] predicate states that the tree [m] is well formed,
+    in the sense that all nodes it contains are not trivially empty. *)
+
+Inductive wf {A} : tree A -> Prop :=
+  | wf_leaf: wf Leaf
+  | wf_node: forall l o r,
+      wf l -> wf r -> not_trivially_empty l o r ->
+      wf (Node l o r).
+
+(** Our type [t A] of extensional tries is a specialized sigma type:
+    it consists of pairs of an original trie [m] and a proof of [wf m]. *)
+
+Record t' (A: Type) := exist { proj1_sig : tree A ; proj2_sig : wf proj1_sig }.
+Definition t := t'.
+Arguments exist : clear implicits.
+
+(** ** Basic operations: [empty], [get], [set], [remove] *)
+
+(** The operations over the sigma type [t A] are derived from those of the
+    original implementation of binary tries, complemented with proofs
+    of well-formedness. *)
+
+Definition empty (A: Type) : t A :=
+  exist _ (Original.PTree.empty A) wf_leaf.
+
+Definition get (A: Type) (i: positive) (m: t A) : option A :=
+  Original.PTree.get i (proj1_sig m).
+
+(** We prove that well-formedness is preserved by the [set] operation:
+    it cannot create a trivially empty node. *)
+
+Lemma set_not_leaf: forall (A: Type) (v: A) i m, Original.PTree.set i v m <> Leaf.
+Proof.
+  destruct i, m; simpl; congruence.
+Qed.
+
+Lemma wf_set: forall (A: Type) (v: A) i m, wf m -> wf (Original.PTree.set i v m).
+Proof.
+  induction i; destruct 1; simpl;
+  auto using wf_leaf, wf_node, not_trivially_empty_left, not_trivially_empty_right, not_trivially_empty_val, set_not_leaf.
+Qed.
+
+Definition set (A: Type) (i: positive) (v: A) (m: t A) : t A :=
+  exist _ (Original.PTree.set i v (proj1_sig m))
+          (wf_set v i (proj2_sig m)).
+
+(** The [Node'] smart constructor never creates a trivially empty node
+    either. *)
+
+Lemma wf_Node': forall A (l: tree A) (o: option A) (r: tree A),
+  wf l -> wf r -> wf (Node' l o r).
+Proof.
+  destruct l, o, r; intros; simpl; constructor; simpl; auto.
+Qed.
+
+(** It follows that the [remove] operation preserves well-formedness. *)
+
+Lemma wf_remove:
+  forall (A: Type) (m: tree A), wf m -> forall i, wf (Original.PTree.remove i m).
+Proof.
+  induction 1; intros; simpl.
+- constructor.
+- destruct i; auto using wf_Node'.
+Qed.
+
+Definition remove (A: Type) (i: positive) (m: t A) : t A :=
+  exist _ (Original.PTree.remove i (proj1_sig m))
+          (wf_remove (proj2_sig m) i).
+
+(** ** Good variable properties for the basic operations *)
+
+(** The characterizations of [empty], [set] and [remove] in terms of
+    [get] queries carry over directly from those of the 
+    original implementation. *)
+
+Theorem gempty:
+  forall (A: Type) (i: positive), get i (empty A) = None.
+Proof. reflexivity. Qed.
+
+Theorem gss:
+  forall (A: Type) (i: positive) (x: A) (m: t A), get i (set i x m) = Some x.
+Proof.
+  intros; destruct m as [m wf]. apply Original.PTree.gss.
+Qed.
+
+Theorem gso:
+  forall (A: Type) (i j: positive) (x: A) (m: t A),
+  i <> j -> get i (set j x m) = get i m.
+Proof.
+  intros; destruct m as [m wf]. apply Original.PTree.gso; auto.
+Qed.
+
+Theorem grs:
+  forall (A: Type) (i: positive) (m: t A), get i (remove i m) = None.
+Proof.
+  intros; destruct m as [m wf]. apply Original.PTree.grs.
+Qed.
+
+Theorem gro:
+  forall (A: Type) (i j: positive) (m: t A),
+  i <> j -> get i (remove j m) = get i m.
+Proof.
+  intros; destruct m as [m wf]. apply Original.PTree.gro; auto.
+Qed.
+
+(** ** Extensionality property *)
+
+(** We first show that for well-formed tries, equivalence implies equality.
+    In other words, the well-formedness criterion rules out all the cases
+    where the original implementation of tries fails the extensionality property. *)
+
+Lemma extensionality_empty:
+  forall A (m: tree A),
+  wf m -> (forall i, Original.PTree.get i m = None) -> m = Leaf.
+Proof.
+  induction 1; simpl; intros E.
+- auto.
+- assert (l = Leaf). { apply IHwf1. intros. apply (E (xO i)). }
+  assert (r = Leaf). { apply IHwf2. intros. apply (E (xI i)). }
+  destruct o eqn:O.
+  specialize (E xH). discriminate.
+  subst l r. simpl in H1. tauto. 
+Qed.
+
+Lemma extensionality_rec:
+  forall A (m1: tree A), wf m1 -> forall (m2: tree A), wf m2 ->
+  (forall i, Original.PTree.get i m1 = Original.PTree.get i m2) ->
+  m1 = m2.
+Proof.
+  induction 1.
+- intros m2 WF2 E. symmetry. apply extensionality_empty; auto.
+  intros. symmetry. apply E.
+- destruct 1; intros E.
+  + apply extensionality_empty. constructor; auto.
+    intros. apply E.
+  + f_equal.
+    * apply IHwf1; auto. intros. apply (E (xO i)).
+    * apply (E xH).
+    * apply IHwf2; auto. intros. apply (E (xI i)).
+Qed.
+
+(** To show that two values of type [t A] are equal, it is not enough to show that
+    their data parts (first projections [proj1_sig]) are equal, which follows
+    from the [extensionality_rec] lemma above: we must also show that their proof parts
+    (second projections [proj2_sig]) are equal too.
+
+    To this end, we need to show the unique proof property for the [wf m] predicate:
+    two proofs of [wf m] are always equal.  We could just assert
+    the proof irrelevance axiom and the result would follow trivially.
+    However, we also have a proof without axioms. *)
+  
+Lemma not_trivially_empty_unique_proofs:
+  forall A (l: tree A) (o: option A) (r: tree A) (p1 p2: not_trivially_empty l o r),
+  p1 = p2.
+Proof.
+  unfold not_trivially_empty; intros.
+  destruct l, o, r, p1, p2; auto.
+Qed.
+
+Lemma wf_unique_proofs:
+  forall A (m: tree A) (p1 p2: wf m), p1 = p2.
+Proof.
+  induction m; intros; dependent destruction p1; dependent destruction p2.
+- auto.
+- f_equal; auto using not_trivially_empty_unique_proofs.
+Qed.
+
+(** The desired extensionality property follows. *)
+
+Theorem extensionality:
+  forall A (m1 m2: t A),
+  (forall i, get i m1 = get i m2) -> m1 = m2.
+Proof.
+  intros A [m1 p1] [m2 p2] E.
+  assert (m1 = m2) by (apply extensionality_rec; auto).
+  subst m2.
+  assert (p1 = p2) by (apply wf_unique_proofs).
+  subst p2.
+  auto.
+Qed.
+
+End PTree.

--- a/_CoqProject
+++ b/_CoqProject
@@ -2,6 +2,8 @@
 Original.v
 Canonical.v
 Sigma.v
+Record.v
+PrimitiveRecord.v
 GADT.v
 Node01.v
 Patricia.v

--- a/benchmark/Benchmark.v
+++ b/benchmark/Benchmark.v
@@ -1,7 +1,7 @@
 From Coq Require Import List String ZArith POrderedType FMaps FMapAVL.
 From Tries.MMaps Require RBT.
 From Tries Require Import String2pos StringOrder PositiveOrder.
-From Tries Require Original Canonical Sigma Node01 GADT Patricia CharTrie.
+From Tries Require Original Canonical Sigma Record PrimitiveRecord Node01 GADT Patricia CharTrie.
 
 Local Open Scope string_scope.
 Local Open Scope list_scope.
@@ -98,6 +98,8 @@ End Test.
 Module TestOriginal := Test Original.PTree.
 Module TestCanonical := Test Canonical.PTree.
 Module TestSigma := Test Sigma.PTree.
+Module TestRecord := Test Record.PTree.
+Module TestPrimitiveRecord := Test PrimitiveRecord.PTree.
 Module TestNode01 := Test Node01.PTree.
 Module TestGADT := Test GADT.PTree.
 Module TestPatricia := Test Patricia.PTree.

--- a/benchmark/Runbench.v
+++ b/benchmark/Runbench.v
@@ -3,108 +3,13 @@ From Tries Require Import Benchmark.
 
 Local Open Scope string_scope.
 
-Compute "AVLpositive (words, x100)".
-Time Eval vm_compute in (repeat 100 TestAVLPositive.bench1 poswords).
-Compute "AVLpositive (small numbers, x1000)".
-Time Eval vm_compute in (repeat 1000 TestAVLPositive.bench1 smallnumbers).
-Compute "AVLpositive (small numbers, cbv, x100)".
-Time Eval cbv in (repeat 100 TestAVLPositive.bench1 smallnumbers).
-Compute "AVLpositive (small numbers, lazy, x100)".
-Time Eval lazy in (repeat 100 TestAVLPositive.bench1 smallnumbers).
-Compute "AVLpositive (repeated keys, x10)".
-Time Eval vm_compute in (repeat 10 TestAVLPositive.bench2 tt).
-
-Compute "RBpositive (words, x100)".
-Time Eval vm_compute in (repeat 100 TestRBPositive.bench1 poswords).
-Compute "RBpositive (small numbers, x1000)".
-Time Eval vm_compute in (repeat 1000 TestRBPositive.bench1 smallnumbers).
-Compute "RBpositive (small numbers, cbv, x100)".
-Time Eval cbv in (repeat 100 TestRBPositive.bench1 smallnumbers).
-Compute "RBpositive (small numbers, lazy, x100)".
-Time Eval lazy in (repeat 100 TestRBPositive.bench1 smallnumbers).
-Compute "RBpositive (repeated keys, x10)".
-Time Eval vm_compute in (repeat 10 TestRBPositive.bench2 tt).
-
-Compute "Original (words, x100)".
-Time Eval vm_compute in (repeat 100 TestOriginal.bench1 poswords).
-Compute "Original (small numbers, x1000)".
-Time Eval vm_compute in (repeat 1000 TestOriginal.bench1 smallnumbers).
-Compute "Original (small numbers, cbv, x100)".
-Time Eval cbv in (repeat 100 TestOriginal.bench1 smallnumbers).
-Compute "Original (small numbers, lazy, x100)".
-Time Eval lazy in (repeat 100 TestOriginal.bench1 smallnumbers).
-Compute "Original (repeated keys, x10)".
-Time Eval vm_compute in (repeat 10 TestOriginal.bench2 tt).
-
-Compute "Canonical (words, x100)".
-Time Eval vm_compute in (repeat 100 TestCanonical.bench1 poswords).
-Compute "Canonical (small numbers, x1000)".
-Time Eval vm_compute in (repeat 1000 TestCanonical.bench1 smallnumbers).
-Compute "Canonical (small numbers, cbv, x100)".
-Time Eval cbv in (repeat 100 TestCanonical.bench1 smallnumbers).
-Compute "Canonical (small numbers, lazy, x100)".
-Time Eval lazy in (repeat 100 TestCanonical.bench1 smallnumbers).
-Compute "Canonical (repeated keys, x10)".
-Time Eval vm_compute in (repeat 10 TestCanonical.bench2 tt).
-
-Compute "Sigma (words, x100)".
-Time Eval vm_compute in (repeat 100 TestSigma.bench1 poswords).
-Compute "Sigma (small numbers, x1000)".
-Time Eval vm_compute in (repeat 1000 TestSigma.bench1 smallnumbers).
-Compute "Sigma (small numbers, cbv, x100)".
-Time Eval cbv in (repeat 100 TestSigma.bench1 smallnumbers).
-Compute "Sigma (small numbers, lazy, x100)".
-Time Eval lazy in (repeat 100 TestSigma.bench1 smallnumbers).
+Compute "PrimitiveRecord (repeated keys, x10)".
+Time Eval vm_compute in (repeat 10 TestPrimitiveRecord.bench2 tt).
+Compute "Record (repeated keys, x10)".
+Time Eval vm_compute in (repeat 10 TestRecord.bench2 tt).
 Compute "Sigma (repeated keys, x10)".
 Time Eval vm_compute in (repeat 10 TestSigma.bench2 tt).
-
-Compute "Node01 (words, x100)".
-Time Eval vm_compute in (repeat 100 TestNode01.bench1 poswords).
-Compute "Node01 (small numbers, x1000)".
-Time Eval vm_compute in (repeat 1000 TestNode01.bench1 smallnumbers).
-Compute "Node01 (small numbers, cbv, x100)".
-Time Eval cbv in (repeat 100 TestNode01.bench1 smallnumbers).
-Compute "Node01 (small numbers, lazy, x100)".
-Time Eval lazy in (repeat 100 TestNode01.bench1 smallnumbers).
-Compute "Node01 (repeated keys, x10)".
-Time Eval vm_compute in (repeat 10 TestNode01.bench2 tt).
-
-Compute "GADT (words, x100)".
-Time Eval vm_compute in (repeat 100 TestGADT.bench1 poswords).
-Compute "GADT (small numbers, x1000)".
-Time Eval vm_compute in (repeat 1000 TestGADT.bench1 smallnumbers).
-Compute "GADT (small numbers, cbv, x100)".
-Time Eval cbv in (repeat 100 TestGADT.bench1 smallnumbers).
-Compute "GADT (small numbers, lazy, x100)".
-Time Eval lazy in (repeat 100 TestGADT.bench1 smallnumbers).
-Compute "GADT (repeated keys, x10)".
-Time Eval vm_compute in (repeat 10 TestGADT.bench2 tt).
-
-Compute "Patricia (words, x100)".
-Time Eval vm_compute in (repeat 100 TestPatricia.bench1 poswords).
-Compute "Patricia (small numbers, x1000)".
-Time Eval vm_compute in (repeat 1000 TestPatricia.bench1 smallnumbers).
-Compute "Patricia (small numbers, cbv, x100)".
-Time Eval cbv in (repeat 100 TestPatricia.bench1 smallnumbers).
-Compute "Patricia (small numbers, lazy, x100)".
-Time Eval lazy in (repeat 100 TestPatricia.bench1 smallnumbers).
-Compute "Patricia (repeated keys, x10)".
-Time Eval vm_compute in (repeat 10 TestPatricia.bench2 tt).
-
-Compute "AVLstring (words, x100)".
-Time Eval vm_compute in (repeat 100 TestAVLString.bench1 words).
-
-Compute "RBstring (words, x100)".
-Time Eval vm_compute in (repeat 100 TestRBString.bench1 words).
-
-Compute "CharTrie (words, x100)".
-Time Eval vm_compute in (repeat 100 TestCharTrie.bench1 words).
-
-Compute "Originalstring (words, x100)".
-Time Eval vm_compute in (repeat 100 TestOriginalAsStringmap.bench1 words).
-
-Compute "Canonicalstring (words, x100)".
-Time Eval vm_compute in (repeat 100 TestCanonicalAsStringmap.bench1 words).
-
-Compute "Patriciastring (words, x100)".
-Time Eval vm_compute in (repeat 100 TestPatriciaAsStringmap.bench1 words).
+Compute "Original (repeated keys, x10)".
+Time Eval vm_compute in (repeat 10 TestOriginal.bench2 tt).
+Compute "Canonical (repeated keys, x10)".
+Time Eval vm_compute in (repeat 10 TestCanonical.bench2 tt).


### PR DESCRIPTION
FYI: I sketched some variants of the Sigma implementation as stand-ins for a similar design space in another library I am working on. Using a dedicated primitive record type does seem to give a speedup, but it is still slower than Original and Canonical.

Benchmarks with coq [master](https://github.com/coq/coq/tree/3964411a73be30e6371b26cce4c6b3d7b8a3522a):

```
coqtop -R . Tries -R mmaps MMaps -batch -load-vernac-source benchmark/Runbench.v
     = "PrimitiveRecord (repeated keys, x10)"
Finished transaction in 20.225 secs (19.499u,0.722s) (successful)
     = "Record (repeated keys, x10)"
Finished transaction in 22.648 secs (22.317u,0.327s) (successful)
     = "Sigma (repeated keys, x10)"
Finished transaction in 30.591 secs (30.194u,0.391s) (successful)
     = "Original (repeated keys, x10)"
Finished transaction in 5.367 secs (5.366u,0.s) (successful)
     = "Canonical (repeated keys, x10)"
Finished transaction in 6.524 secs (6.523u,0.s) (successful)
```


Benchmarks with https://github.com/silene/coq/tree/VMaccu2 https://github.com/coq/coq/pull/18917 (I am just an eager early user of this work-in-progress vm improvement; my experimentation here does not constitute any statement of readiness by its authors):

```
coqtop -R . Tries -R mmaps MMaps -batch -load-vernac-source benchmark/Runbench.v
     = "PrimitiveRecord (repeated keys, x10)"
Finished transaction in 7.77 secs (7.764u,0.004s) (successful)
     = "Record (repeated keys, x10)"
Finished transaction in 11.891 secs (11.889u,0.s) (successful)
     = "Sigma (repeated keys, x10)"
Finished transaction in 15.065 secs (15.054u,0.007s) (successful)
     = "Original (repeated keys, x10)"
Finished transaction in 5.366 secs (5.365u,0.s) (successful)
     = "Canonical (repeated keys, x10)"
Finished transaction in 6.505 secs (6.504u,0.s) (successful)
```

This PR includes unrelated changes blatantly hacking around https://github.com/xavierleroy/canonical-binary-tries/issues/1, but in principle I could clean it up.